### PR TITLE
fix 'cannot load such file -- args_parser' error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     irkit (0.0.5)
+      args_parser
       dnssd
       hashie
       httparty
@@ -10,6 +11,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    args_parser (0.2.0)
     dnssd (2.0)
     hashie (2.0.5)
     httparty (0.13.0)

--- a/irkit.gemspec
+++ b/irkit.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "httparty"
   spec.add_dependency "json"
   spec.add_dependency "hashie"
+  spec.add_dependency "args_parser"
 end


### PR DESCRIPTION
I found `irkit` command raises `LoadError`.
So this pull-req fixes the problem.

```
$ irkit --help
/Users/mallowlabs/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:53:in `require': cannot load such file -- args_parser (LoadError)
    from /Users/mallowlabs/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:53:in `require'
    from /Users/mallowlabs/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/irkit-0.0.5/bin/irkit:6:in `<top (required)>'
    from /Users/mallowlabs/.rbenv/versions/2.0.0-p353/bin/irkit:23:in `load'
    from /Users/mallowlabs/.rbenv/versions/2.0.0-p353/bin/irkit:23:in `<main>'
```
