### PR TITLE
Use open-uri for IRKit::App::Data

### DIFF
--- a/lib/irkit/app/data.rb
+++ b/lib/irkit/app/data.rb
@@ -1,12 +1,13 @@
 require 'yaml'
+require 'open-uri'
 
 module IRKit
   module App
 
     DATA_FILE = ENV["IRKIT_DATA_FILE"] || File.expand_path('.irkit.json', ENV['HOME'])
 
-    if File.exists?(DATA_FILE)
-      Data = Hashie::Mash.new JSON.parse(File.open(DATA_FILE).read)
+    if File.exists?(DATA_FILE) || DATA_FILE =~ /\A#{URI::regexp(['http', 'https'])}\z/
+      Data = Hashie::Mash.new JSON.parse(open(DATA_FILE).read)
     else
       Data = Hashie::Mash.new("IR" => {}, "Device" => {})
     end


### PR DESCRIPTION
I want to keep my `irkit.json` secret from my application repository itself, so I made this change to use `open-uri` for `IRKit::App::Data` like below:

````
$ IRKIT_DATA_FILE=https://gist.githubusercontent.com/riywo/.../irkit.json irkit --list
~> https://gist.githubusercontent.com/riywo/.../irkit.json
== Data
foo
bar
== Devices
living	Internet API
10.0.1.17	irkit933c (bonjour)
````

This makes easy to use ruby-irkit in Heroku.

Thanks!